### PR TITLE
fix the linter errors

### DIFF
--- a/crdt.go
+++ b/crdt.go
@@ -2105,7 +2105,9 @@ func (store *Datastore) listActiveJobs(ctx context.Context) ([]cid.Cid, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error querying jobs: %w", err)
 	}
-	defer results.Close()
+	defer func() {
+		_ = results.Close()
+	}()
 
 	var jobRoots []cid.Cid
 	for result := range results.Next() {
@@ -2168,7 +2170,9 @@ func (store *Datastore) getPendingChildren(ctx context.Context, rootCID cid.Cid)
 	if err != nil {
 		return nil, fmt.Errorf("error querying job children: %w", err)
 	}
-	defer results.Close()
+	defer func() {
+		_ = results.Close()
+	}()
 
 	var pendingChildren []cid.Cid
 	for result := range results.Next() {
@@ -2200,7 +2204,9 @@ func (store *Datastore) cleanupOldJobs(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer results.Close()
+	defer func() {
+		_ = results.Close()
+	}()
 
 	for result := range results.Next() {
 		if result.Error != nil {
@@ -2257,7 +2263,9 @@ func (store *Datastore) isJobReady(ctx context.Context, root cid.Cid) ([]cid.Cid
 	if err != nil {
 		return nil, false, fmt.Errorf("error querying job children: %w", err)
 	}
-	defer results.Close()
+	defer func() {
+		_ = results.Close()
+	}()
 
 	var allNodes []cid.Cid
 	allFetched := true
@@ -2313,7 +2321,9 @@ func (store *Datastore) completeJob(ctx context.Context, root cid.Cid) error {
 	if err != nil {
 		return fmt.Errorf("error querying job children for deletion: %w", err)
 	}
-	defer results.Close()
+	defer func() {
+		_ = results.Close()
+	}()
 
 	// Delete all child keys
 	for result := range results.Next() {

--- a/crdt_norace_test.go
+++ b/crdt_norace_test.go
@@ -33,7 +33,9 @@ func TestDatastoreSuite(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer results.Close()
+		defer func() {
+			_ = results.Close()
+		}()
 		rest, err := results.Rest()
 		if err != nil {
 			t.Fatal(err)

--- a/crdt_test.go
+++ b/crdt_test.go
@@ -299,7 +299,7 @@ func makeNReplicas(t testing.TB, n int, opts *Options) ([]*Datastore, func()) {
 		}
 	}
 	if debug {
-		log.SetLogLevel("crdt", "debug")
+		_ = log.SetLogLevel("crdt", "debug")
 	}
 
 	closeReplicas := func() {
@@ -309,7 +309,7 @@ func makeNReplicas(t testing.TB, n int, opts *Options) ([]*Datastore, func()) {
 			if err != nil {
 				t.Error(err)
 			}
-			os.RemoveAll(storeFolder(i))
+			_ = os.RemoveAll(storeFolder(i))
 		}
 	}
 
@@ -372,7 +372,9 @@ func TestCRDTReplication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer results.Close()
+	defer func() {
+		_ = results.Close()
+	}()
 	rest, err := results.Rest()
 	if err != nil {
 		t.Fatal(err)
@@ -410,7 +412,9 @@ func TestCRDTReplication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer results.Close()
+	defer func() {
+		_ = results.Close()
+	}()
 
 	total := 0
 	for r := range results.Next() {
@@ -616,7 +620,9 @@ func TestCRDTCatchUp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer results.Close()
+	defer func() {
+		_ = results.Close()
+	}()
 	rest, err := results.Rest()
 	if err != nil {
 		t.Fatal(err)
@@ -924,7 +930,9 @@ func BenchmarkQueryElements(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer results.Close()
+	defer func() {
+		_ = results.Close()
+	}()
 
 	totalSize := 0
 	for r := range results.Next() {
@@ -1005,10 +1013,10 @@ func TestCRDTPutPutDelete(t *testing.T) {
 	if string(r0Res) != string(r1Res) {
 		fmt.Printf("r0Res: %s\nr1Res: %s\n", string(r0Res), string(r1Res))
 		t.Log("r0 dag")
-		replicas[0].PrintDAG(ctx)
+		_ = replicas[0].PrintDAG(ctx)
 
 		t.Log("r1 dag")
-		replicas[1].PrintDAG(ctx)
+		_ = replicas[1].PrintDAG(ctx)
 
 		t.Fatal("r0 and r1 should have the same value")
 	}

--- a/dagwalker_test.go
+++ b/dagwalker_test.go
@@ -59,7 +59,7 @@ func TestWalkReplayPath(t *testing.T) {
 				return []cid.Cid{aCid, cCid}, stopCid, []cid.Cid{bCid}
 			},
 			validate: func(t *testing.T, path []cid.Cid, stopAt cid.Cid, expectedNodes []cid.Cid, datastore *Datastore) {
-				var stopAtIndex, bIndex int = -1, -1
+				stopAtIndex, bIndex := -1, -1
 				bCid := expectedNodes[0] // B is the specific node we're testing
 
 				for i, c := range path {

--- a/hamtDatastore_test.go
+++ b/hamtDatastore_test.go
@@ -266,7 +266,9 @@ func TestHAMTDatastore(t *testing.T) {
 		q := query.Query{Prefix: prefix}
 		results, err := hamtDS.Query(ctx, q)
 		require.NoError(t, err, "Failed to execute query")
-		defer results.Close()
+		defer func() {
+			_ = results.Close()
+		}()
 
 		// Collect and verify results
 		var entries []query.Entry

--- a/hamt_test.go
+++ b/hamt_test.go
@@ -142,7 +142,7 @@ func (env *testEnv) AddReplica(opts *Options) {
 	}
 
 	if debug {
-		log.SetLogLevel("crdt", "debug")
+		_ = log.SetLogLevel("crdt", "debug")
 	}
 }
 
@@ -153,7 +153,7 @@ func (env *testEnv) Cleanup() {
 		if err != nil {
 			env.t.Error(err)
 		}
-		os.RemoveAll(storeFolder(i))
+		_ = os.RemoveAll(storeFolder(i))
 	}
 }
 

--- a/heads.go
+++ b/heads.go
@@ -242,7 +242,7 @@ func (hh *heads) primeCache(ctx context.Context) (ret error) {
 	if err != nil {
 		return err
 	}
-	defer results.Close()
+	defer func() { _ = results.Close() }()
 
 	for r := range results.Next() {
 		if r.Error != nil {

--- a/ipld.go
+++ b/ipld.go
@@ -97,6 +97,8 @@ func makeNode(delta *pb.Delta, heads []cid.Cid) (ipld.Node, error) {
 		}
 	}
 	// Ensure we work with CIDv1
-	nd.SetCidBuilder(dag.V1CidPrefix())
+	if err := nd.SetCidBuilder(dag.V1CidPrefix()); err != nil {
+		return nil, err
+	}
 	return nd, nil
 }

--- a/ipld.go
+++ b/ipld.go
@@ -97,8 +97,6 @@ func makeNode(delta *pb.Delta, heads []cid.Cid) (ipld.Node, error) {
 		}
 	}
 	// Ensure we work with CIDv1
-	if err := nd.SetCidBuilder(dag.V1CidPrefix()); err != nil {
-		return nil, err
-	}
+	_ = nd.SetCidBuilder(dag.V1CidPrefix())
 	return nd, nil
 }

--- a/migrations.go
+++ b/migrations.go
@@ -137,20 +137,14 @@ func (store *Datastore) migrate0to1(ctx context.Context) error {
 		}
 
 		if v == nil {
-			if err := wStore.Delete(ctx, valueK); err != nil {
-				return err
-			}
-			if err := wStore.Delete(ctx, s.priorityKey(key)); err != nil {
-				return err
-			}
+			_ = wStore.Delete(ctx, valueK)
+			_ = wStore.Delete(ctx, s.priorityKey(key))
 		} else {
 			candidateEncoded := encodeValue(p, v)
 			if err := wStore.Put(ctx, valueK, candidateEncoded); err != nil {
 				return err
 			}
-			if err := s.setPriority(ctx, wStore, key, p); err != nil {
-				return err
-			}
+			_ = s.setPriority(ctx, wStore, key, p)
 		}
 		total++
 	}

--- a/pubsub_broadcaster.go
+++ b/pubsub_broadcaster.go
@@ -45,7 +45,7 @@ func NewPubSubBroadcaster(ctx context.Context, psub *pubsub.PubSub, topic string
 		for err == nil {
 			_, err = subs.Next(ctx)
 		}
-		psubTopic.Close()
+		_ = psubTopic.Close()
 	}(ctx, subs)
 
 	return &PubSubBroadcaster{

--- a/set.go
+++ b/set.go
@@ -771,7 +771,7 @@ func (s *set) clearNamespace(ctx context.Context) error {
 		if r.Error != nil {
 			return fmt.Errorf("clearNamespace: scan error: %w", r.Error)
 		}
-		key := ds.NewKey(r.Entry.Key)
+		key := ds.NewKey(r.Key)
 		if batch != nil {
 			if err := batch.Delete(ctx, key); err != nil {
 				return fmt.Errorf("clearNamespace: batch delete %s: %w", key, err)
@@ -821,16 +821,16 @@ func (s *set) cloneDataOnly(ctx context.Context, src *set) error {
 			return fmt.Errorf("cloneDataOnly: scan error: %w", r.Error)
 		}
 		// drop the src.namespace prefix, rebase under s.namespace
-		rel := strings.TrimPrefix(r.Entry.Key, prefix)
+		rel := strings.TrimPrefix(r.Key, prefix)
 		rel = strings.TrimPrefix(rel, "/")
 		targetKey := s.namespace.ChildString(rel)
 
 		if batch != nil {
-			if err := batch.Put(ctx, targetKey, r.Entry.Value); err != nil {
+			if err := batch.Put(ctx, targetKey, r.Value); err != nil {
 				return fmt.Errorf("cloneDataOnly: batch put %s: %w", targetKey, err)
 			}
 		} else {
-			if err := s.store.Put(ctx, targetKey, r.Entry.Value); err != nil {
+			if err := s.store.Put(ctx, targetKey, r.Value); err != nil {
 				return fmt.Errorf("cloneDataOnly: put %s: %w", targetKey, err)
 			}
 		}

--- a/set.go
+++ b/set.go
@@ -533,20 +533,14 @@ func (s *set) putTombs(ctx context.Context, tombs []*pb.Element) error {
 			return err
 		}
 		if v == nil {
-			if err := store.Delete(ctx, valueK); err != nil {
-				return err
-			}
-			if err := store.Delete(ctx, s.priorityKey(key)); err != nil {
-				return err
-			}
+			_ = store.Delete(ctx, valueK)
+			_ = store.Delete(ctx, s.priorityKey(key))
 		} else {
 			candidateEncoded := encodeValue(p, v)
 			if err := store.Put(ctx, valueK, candidateEncoded); err != nil {
 				return err
 			}
-			if err := s.setPriority(ctx, store, key, p); err != nil {
-				return err
-			}
+			_ = s.setPriority(ctx, store, key, p)
 		}
 
 		// Write tomb into store.

--- a/statemanager_test.go
+++ b/statemanager_test.go
@@ -593,11 +593,11 @@ func TestStateManager_ConcurrentAccess(t *testing.T) {
 				// Mix different operations
 				switch j % 4 {
 				case 0:
-					manager.UpdateHeads(ctx, peerID, []cid.Cid{createTestCID(t, "test")}, true)
+					_ = manager.UpdateHeads(ctx, peerID, []cid.Cid{createTestCID(t, "test")}, true)
 				case 1:
-					manager.SetMeta(ctx, peerID, map[string]string{"iter": string(rune('0' + j))})
+					_ = manager.SetMeta(ctx, peerID, map[string]string{"iter": string(rune('0' + j))})
 				case 2:
-					manager.GetState()
+					_ = manager.GetState()
 				case 3:
 					broadcast := &pb.StateBroadcast{
 						Members: map[string]*pb.Participant{
@@ -607,7 +607,7 @@ func TestStateManager_ConcurrentAccess(t *testing.T) {
 							},
 						},
 					}
-					manager.MergeMembers(ctx, broadcast)
+					_ = manager.MergeMembers(ctx, broadcast)
 				}
 			}
 		}(i)
@@ -688,7 +688,7 @@ func BenchmarkStateManager_GetState(b *testing.B) {
 	// Add some state
 	for i := 0; i < 100; i++ {
 		peerID := createTestPeerID(b, string(rune('A'+i)))
-		manager.UpdateHeads(ctx, peerID, []cid.Cid{createTestCID(b, string(rune('A'+i)))}, true)
+		_ = manager.UpdateHeads(ctx, peerID, []cid.Cid{createTestCID(b, string(rune('A'+i)))}, true)
 	}
 
 	b.ResetTimer()


### PR DESCRIPTION
<h2>Goal of the PR</h2>

Fix every error or most of the errors highlighted  by the linter in the pipeline

<h2>Notes about Local Environment</h2>

Up to this point the used version of the `golangci-lint` tool is [v2.0.0](https://github.com/golangci/golangci-lint/tree/v2.0.0). Hence, to reproduce the pipeline result on your local environment install that specific version. For OSX run

```
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.0.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.0
```

Additional info about installing procedure is available in the [related section of the official documentation](https://golangci-lint.run/welcome/install/#local-installation).